### PR TITLE
Update ORIENTATION-en.md to say 10 weeks, not 8 weeks 

### DIFF
--- a/ORIENTATION-en.md
+++ b/ORIENTATION-en.md
@@ -40,7 +40,7 @@ A task or story is “done” when the following are all true:
 
 Each week the team will split into pairs and each pair will be responsible for completing a single story from the backlog.
 
-At the end of the 8 week project all of the stories will be complete and we will have a beautifully functioning app that the team has collaboratively built!
+At the end of the 10 week project all of the stories will be complete and we will have a beautifully functioning app that the team has collaboratively built!
 
 ### Coordination & communication
 


### PR DESCRIPTION
_For an example of how to fill this template out, [see this Pull Request](https://github.com/the-collab-lab/tcl-3-smart-shopping-list/pull/44)._

## Description

We recently went through an overhaul of the program, taking it from 8 weeks to 10 week. This PR reflects those changes in the ORIENTATION document we'll cover tomorrow live with the whole cohort. 🎉 

## Type of Changes

`copy change` 

