### PR TITLE
Feature/ts-rb-purchase-date-util #11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
 		"": {
 			"name": "smart-shopping-list-next",
 			"dependencies": {
+				"@the-collab-lab/shopping-list-utils": "^2.2.0",
 				"firebase": "^10.1.0",
 				"react": "^18.2.0",
 				"react-dom": "^18.2.0",
@@ -3992,6 +3993,15 @@
 			},
 			"peerDependencies": {
 				"@testing-library/dom": ">=7.21.4"
+			}
+		},
+		"node_modules/@the-collab-lab/shopping-list-utils": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@the-collab-lab/shopping-list-utils/-/shopping-list-utils-2.2.0.tgz",
+			"integrity": "sha512-nEN1z/SEOIWO+8JWIgPDNUkrXmXqNomSh5aiZDNdiaUH/JYqyNeXmEOldtMqAfLicSRiFkapcAIlrUUnPzNaog==",
+			"peerDependencies": {
+				"react": "^18.2.0",
+				"react-dom": "^18.2.0"
 			}
 		},
 		"node_modules/@tootallnate/once": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
 		"npm": ">=8.19.0"
 	},
 	"dependencies": {
+		"@the-collab-lab/shopping-list-utils": "^2.2.0",
 		"firebase": "^10.1.0",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -10,7 +10,7 @@ import {
 } from 'firebase/firestore';
 import { useEffect, useState } from 'react';
 import { db } from './config';
-import { getFutureDate } from '../utils';
+import { getFutureDate, getDaysBetweenDates } from '../utils';
 
 /**
  * A custom hook that subscribes to the user's shopping lists in our Firestore

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -53,6 +53,7 @@ export function ListItem({ item, listPath }) {
 
 		const updatedTimeSTamp = Timestamp.fromDate(currentDate);
 
+		// this should be the final conversion to firebase's date format.
 		console.log(updatedTimeSTamp.toDate());
 		return updatedTimeSTamp.toDate();
 	}

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -4,6 +4,7 @@ import { updateItem } from '../api/firebase';
 import { useMutation } from 'react-query';
 import { calculateEstimate } from '@the-collab-lab/shopping-list-utils';
 import { getDaysBetweenDates } from '../utils/dates';
+import { Timestamp } from 'firebase/firestore';
 
 export function ListItem({ item, listPath }) {
 	const { id, totalPurchases, name, dateLastPurchased, dateNextPurchased } =
@@ -39,13 +40,13 @@ export function ListItem({ item, listPath }) {
 		// console.log(
 		// 	calculateEstimate(
 		// 		dateNextPurchased,
-		// 		getDaysBetweenDates(dateLastPurchased, dateNextPurchased),
+		// 		getDaysBetweenDates(Timestamp.now(), dateLastPurchased),
 		// 		totalPurchases,
 		// 	),
 		// );
 
 		// testing just getDaysBetweenDates
-		console.log(getDaysBetweenDates(dateLastPurchased, dateNextPurchased));
+		console.log(getDaysBetweenDates(Timestamp.now(), dateLastPurchased));
 	}
 
 	const isDisabled = isChecked || isLoading;

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -31,15 +31,29 @@ export function ListItem({ item, listPath }) {
 		mutationFn: markAsPurchased,
 	});
 
+	const previousEstimate = getDaysBetweenDates(
+		dateNextPurchased,
+		dateLastPurchased,
+	);
+
+	// console.log(
+	// 	calculateEstimate(
+	// 		previousEstimate,
+	// 		getDaysBetweenDates(Timestamp.now(), dateLastPurchased),
+	// 		totalPurchases,
+	// 	),
+	// );
+
 	async function markAsPurchased() {
 		await updateItem(listPath, {
 			itemId: id,
 			totalPurchases: totalPurchases,
 		});
 		// testing the calculate estimate
+
 		console.log(
 			calculateEstimate(
-				dateNextPurchased,
+				previousEstimate,
 				getDaysBetweenDates(Timestamp.now(), dateLastPurchased),
 				totalPurchases,
 			),

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -36,31 +36,16 @@ export function ListItem({ item, listPath }) {
 		dateLastPurchased,
 	);
 
-	// console.log(
-	// 	calculateEstimate(
-	// 		previousEstimate,
-	// 		getDaysBetweenDates(Timestamp.now(), dateLastPurchased),
-	// 		totalPurchases,
-	// 	),
-	// );
-
 	async function markAsPurchased() {
 		await updateItem(listPath, {
 			itemId: id,
 			totalPurchases: totalPurchases,
-		});
-		// testing the calculate estimate
-
-		console.log(
-			calculateEstimate(
+			dateNextPurchased: calculateEstimate(
 				previousEstimate,
 				getDaysBetweenDates(Timestamp.now(), dateLastPurchased),
 				totalPurchases,
 			),
-		);
-
-		// testing just getDaysBetweenDates
-		console.log(getDaysBetweenDates(Timestamp.now(), dateLastPurchased));
+		});
 	}
 
 	const isDisabled = isChecked || isLoading;

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import './ListItem.css';
 import { updateItem } from '../api/firebase';
 import { useMutation } from 'react-query';
+import { getNextPurchasedDate } from '../utils';
 
 export function ListItem({ item, listPath }) {
 	const { id, totalPurchases, name, dateLastPurchased, dateNextPurchased } =
@@ -29,11 +30,16 @@ export function ListItem({ item, listPath }) {
 	});
 
 	async function markAsPurchased() {
+		const nextPurchasedDate = getNextPurchasedDate({
+			dateLastPurchased,
+			dateNextPurchased,
+			totalPurchases,
+		});
+
 		await updateItem(listPath, {
 			itemId: id,
 			totalPurchases: totalPurchases,
-			dateLastPurchased: dateLastPurchased,
-			dateNextPurchased: dateNextPurchased,
+			dateNextPurchased: nextPurchasedDate,
 		});
 	}
 

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -37,13 +37,13 @@ export function ListItem({ item, listPath }) {
 			totalPurchases: totalPurchases,
 		});
 		// testing the calculate estimate
-		// console.log(
-		// 	calculateEstimate(
-		// 		dateNextPurchased,
-		// 		getDaysBetweenDates(Timestamp.now(), dateLastPurchased),
-		// 		totalPurchases,
-		// 	),
-		// );
+		console.log(
+			calculateEstimate(
+				dateNextPurchased,
+				getDaysBetweenDates(Timestamp.now(), dateLastPurchased),
+				totalPurchases,
+			),
+		);
 
 		// testing just getDaysBetweenDates
 		console.log(getDaysBetweenDates(Timestamp.now(), dateLastPurchased));

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -3,7 +3,7 @@ import './ListItem.css';
 import { updateItem } from '../api/firebase';
 import { useMutation } from 'react-query';
 import { calculateEstimate } from '@the-collab-lab/shopping-list-utils';
-import { getDaysBetweenDates } from '../utils/dates';
+import { getDaysBetweenDates, ONE_DAY_IN_MILLISECONDS } from '../utils/dates';
 import { Timestamp } from 'firebase/firestore';
 
 export function ListItem({ item, listPath }) {
@@ -36,15 +36,32 @@ export function ListItem({ item, listPath }) {
 		dateLastPurchased,
 	);
 
+	function estimateAddedToNow() {
+		// converts estmated days to milliseconds, and then adds it to current time
+		// milliseconds.
+		const estDaysToMilli =
+			calculateEstimate(
+				previousEstimate,
+				getDaysBetweenDates(Timestamp.now(), dateLastPurchased),
+				totalPurchases,
+			) * ONE_DAY_IN_MILLISECONDS;
+
+		const currentDate = Timestamp.now().toDate();
+
+		//adding milliseconds to date
+		currentDate.setTime(currentDate.getTime() + estDaysToMilli);
+
+		const updatedTimeSTamp = Timestamp.fromDate(currentDate);
+
+		console.log(updatedTimeSTamp.toDate());
+		return updatedTimeSTamp.toDate();
+	}
+
 	async function markAsPurchased() {
 		await updateItem(listPath, {
 			itemId: id,
 			totalPurchases: totalPurchases,
-			dateNextPurchased: calculateEstimate(
-				previousEstimate,
-				getDaysBetweenDates(Timestamp.now(), dateLastPurchased),
-				totalPurchases,
-			),
+			dateNextPurchased: estimateAddedToNow(),
 		});
 	}
 

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -4,14 +4,8 @@ import { updateItem } from '../api/firebase';
 import { useMutation } from 'react-query';
 
 export function ListItem({ item, listPath }) {
-	const {
-		id,
-		totalPurchases,
-		name,
-		dateLastPurchased,
-		dateNextPurchased,
-		dateCreated,
-	} = item;
+	const { id, totalPurchases, name, dateLastPurchased, dateNextPurchased } =
+		item;
 
 	const isLessThan24HoursSinceLastPurchased =
 		compareIfDateIsLessThan24Hours(dateLastPurchased);
@@ -40,7 +34,6 @@ export function ListItem({ item, listPath }) {
 			totalPurchases: totalPurchases,
 			dateLastPurchased: dateLastPurchased,
 			dateNextPurchased: dateNextPurchased,
-			dateCreated: dateCreated,
 		});
 	}
 

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -2,9 +2,12 @@ import React, { useState } from 'react';
 import './ListItem.css';
 import { updateItem } from '../api/firebase';
 import { useMutation } from 'react-query';
+import { calculateEstimate } from '@the-collab-lab/shopping-list-utils';
+import { getDaysBetweenDates } from '../utils/dates';
 
 export function ListItem({ item, listPath }) {
-	const { id, totalPurchases, name, dateLastPurchased } = item;
+	const { id, totalPurchases, name, dateLastPurchased, dateNextPurchased } =
+		item;
 
 	const isLessThan24HoursSinceLastPurchased =
 		compareIfDateIsLessThan24Hours(dateLastPurchased);
@@ -32,6 +35,17 @@ export function ListItem({ item, listPath }) {
 			itemId: id,
 			totalPurchases: totalPurchases,
 		});
+		// testing the calculate estimate
+		// console.log(
+		// 	calculateEstimate(
+		// 		dateNextPurchased,
+		// 		getDaysBetweenDates(dateLastPurchased, dateNextPurchased),
+		// 		totalPurchases,
+		// 	),
+		// );
+
+		// testing just getDaysBetweenDates
+		console.log(getDaysBetweenDates(dateLastPurchased, dateNextPurchased));
 	}
 
 	const isDisabled = isChecked || isLoading;
@@ -39,7 +53,12 @@ export function ListItem({ item, listPath }) {
 	async function handleCheckboxCheck() {
 		setIsChecked(!isChecked);
 		if (!isChecked) {
-			await markAsPurchasedMutation({ listPath, id, totalPurchases });
+			await markAsPurchasedMutation({
+				listPath,
+				id,
+				totalPurchases,
+				dateNextPurchased,
+			});
 		}
 	}
 

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -1,4 +1,4 @@
-const ONE_DAY_IN_MILLISECONDS = 86400000;
+export const ONE_DAY_IN_MILLISECONDS = 86400000;
 
 /**
  * Get a new JavaScript Date that is `offset` days in the future.

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -12,22 +12,25 @@ export function getFutureDate(offset) {
 }
 
 export function getDaysBetweenDates(startDate, endDate) {
-	// console.log(
-	// 	`startDate: ${startDate}\n\n endDate: ${endDate}\n\n endDateToDate: ${endDate.toDate()} \n\n startDateToDate: ${startDate.toDate()} \n\n
-	// 	startDateMilli ${startDate.toMillis()}`,
-	// );
+	// New items are created without a startDate. This avoids null type
+	// error on new item creation.
+	if (!startDate) {
+		return;
+	}
 
 	// the .toDate method converts date formatting to milliseconds.
 	// divinding these days by ONE_DAY_IN_MILLISECONDS, gives you the total
 	// ammount of days after the difference is established.
-	const difference = startDate.toDate() - endDate.toDate();
-	const calculation = Math.floor(difference / ONE_DAY_IN_MILLISECONDS);
+	if (startDate && endDate) {
+		const difference = startDate.toDate() - endDate.toDate();
+		const calculation = Math.floor(difference / ONE_DAY_IN_MILLISECONDS);
 
-	// if number cannot divide evenly into a number more than 1, than less than a day has
-	// passed. Defaults to 0.
-	if (calculation <= 0) {
-		return 0;
-	} else {
-		return calculation;
+		// if number cannot divide evenly into a number more than 1, than less than a day has
+		// passed. Defaults to 0.
+		if (calculation <= 0) {
+			return 0;
+		} else {
+			return calculation;
+		}
 	}
 }

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -10,3 +10,14 @@ const ONE_DAY_IN_MILLISECONDS = 86400000;
 export function getFutureDate(offset) {
 	return new Date(Date.now() + offset * ONE_DAY_IN_MILLISECONDS);
 }
+
+export function getDaysBetweenDates(startDate, endDate) {
+	let difference = 0;
+
+	if (startDate) {
+		difference = startDate.toDate() - endDate.toDate();
+		return Math.floor(difference / ONE_DAY_IN_MILLISECONDS);
+	} else {
+		return 0;
+	}
+}

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -1,3 +1,5 @@
+import { calculateEstimate } from '@the-collab-lab/shopping-list-utils';
+
 export const ONE_DAY_IN_MILLISECONDS = 86400000;
 
 /**
@@ -35,4 +37,44 @@ export function getDaysBetweenDates(dateLastPurchase, dateNextPurchase) {
 			return numOfDaysBetweenCalculation;
 		}
 	}
+}
+
+export function getNextPurchasedDate({
+	dateLastPurchased,
+	dateNextPurchased,
+	totalPurchases,
+}) {
+	const today = new Date();
+
+	/**
+	 * Calculate the previous estimate for purchase
+	 * based on historical data
+	 */
+
+	const previousEstimate = getDaysBetweenDates(
+		dateLastPurchased?.toDate() ? dateLastPurchased?.toDate() : today,
+		dateNextPurchased.toDate(),
+	);
+
+	/**
+	 * Calculate the days since the last purchase,
+	 * considering either date last purchased or the created date
+	 */
+	const daysSinceLastPurchase = getDaysBetweenDates(
+		today,
+		dateLastPurchased ? dateLastPurchased?.toDate() : today,
+	);
+
+	let smartNextPurchaseEstimate = calculateEstimate(
+		previousEstimate,
+		daysSinceLastPurchase ? daysSinceLastPurchase : previousEstimate,
+		totalPurchases,
+	);
+
+	// Ensure that the next purchase date is at least one day in the future
+	if (smartNextPurchaseEstimate <= 0) {
+		smartNextPurchaseEstimate = 1;
+	}
+
+	return getFutureDate(smartNextPurchaseEstimate);
 }

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -18,18 +18,22 @@ export function getDaysBetweenDates(startDate, endDate) {
 		return;
 	}
 
+	console.log('startDate: ', startDate, 'endDate: ', endDate);
+
 	// the .toDate method converts date formatting to milliseconds.
 	// divinding these days by ONE_DAY_IN_MILLISECONDS, gives you the total
 	// ammount of days after the difference is established.
 	if (startDate && endDate) {
-		const difference = startDate.toDate() - endDate.toDate();
+		const difference = startDate - endDate;
 		const calculation = Math.floor(difference / ONE_DAY_IN_MILLISECONDS);
 
 		// if number cannot divide evenly into a number more than 1, than less than a day has
 		// passed. Defaults to 0.
 		if (calculation <= 0) {
+			console.log('zero');
 			return 0;
 		} else {
+			console.log(calculation);
 			return calculation;
 		}
 	}

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -11,30 +11,28 @@ export function getFutureDate(offset) {
 	return new Date(Date.now() + offset * ONE_DAY_IN_MILLISECONDS);
 }
 
-export function getDaysBetweenDates(startDate, endDate) {
+export function getDaysBetweenDates(dateLastPurchase, dateNextPurchase) {
 	// New items are created without a startDate. This avoids null type
 	// error on new item creation.
-	if (!startDate) {
+	if (!dateLastPurchase) {
 		return;
 	}
-
-	console.log('startDate: ', startDate, 'endDate: ', endDate);
 
 	// the .toDate method converts date formatting to milliseconds.
 	// divinding these days by ONE_DAY_IN_MILLISECONDS, gives you the total
 	// ammount of days after the difference is established.
-	if (startDate && endDate) {
-		const difference = startDate - endDate;
-		const calculation = Math.floor(difference / ONE_DAY_IN_MILLISECONDS);
+	if (dateLastPurchase && dateNextPurchase) {
+		const difference = dateLastPurchase - dateNextPurchase;
+		const numOfDaysBetweenCalculation = Math.floor(
+			difference / ONE_DAY_IN_MILLISECONDS,
+		);
 
 		// if number cannot divide evenly into a number more than 1, than less than a day has
 		// passed. Defaults to 0.
-		if (calculation <= 0) {
-			console.log('zero');
+		if (numOfDaysBetweenCalculation <= 0) {
 			return 0;
 		} else {
-			console.log(calculation);
-			return calculation;
+			return numOfDaysBetweenCalculation;
 		}
 	}
 }

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -12,12 +12,22 @@ export function getFutureDate(offset) {
 }
 
 export function getDaysBetweenDates(startDate, endDate) {
-	let difference = 0;
+	// console.log(
+	// 	`startDate: ${startDate}\n\n endDate: ${endDate}\n\n endDateToDate: ${endDate.toDate()} \n\n startDateToDate: ${startDate.toDate()} \n\n
+	// 	startDateMilli ${startDate.toMillis()}`,
+	// );
 
-	if (startDate) {
-		difference = startDate.toDate() - endDate.toDate();
-		return Math.floor(difference / ONE_DAY_IN_MILLISECONDS);
+	// the .toDate method converts date formatting to milliseconds.
+	// divinding these days by ONE_DAY_IN_MILLISECONDS, gives you the total
+	// ammount of days after the difference is established.
+	const difference = startDate.toDate() - endDate.toDate();
+	const calculation = Math.floor(difference / ONE_DAY_IN_MILLISECONDS);
+
+	// if number cannot divide evenly into a number more than 1, than less than a day has
+	// passed. Defaults to 0.
+	if (calculation <= 0) {
+		return calculation;
 	} else {
-		return 0;
+		return calculation;
 	}
 }

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -26,7 +26,7 @@ export function getDaysBetweenDates(startDate, endDate) {
 	// if number cannot divide evenly into a number more than 1, than less than a day has
 	// passed. Defaults to 0.
 	if (calculation <= 0) {
-		return calculation;
+		return 0;
 	} else {
 		return calculation;
 	}

--- a/vite.config.js
+++ b/vite.config.js
@@ -33,7 +33,6 @@ const PWAConfig = {
 		background_color: '#ffffff',
 	},
 };
-
 // https://vitejs.dev/config/
 export default defineConfig({
 	build: {
@@ -60,6 +59,7 @@ export default defineConfig({
 	plugins: [react(), svgr({ exportAsDefault: true }), VitePWA(PWAConfig)],
 	server: { open: true, port: 3000 },
 	test: {
+		pool: 'vmThreads',
 		globals: true,
 		environment: 'jsdom',
 		setupFiles: './tests/setup.js',


### PR DESCRIPTION
## Description

In order to advise users about when to purchase things, the app needs to be able to calculate that guess and store it a future date.

The calculateEstimate function from the @the-collab-lab/shopping-list-utils module will help us know how many days in the future a purchase should happen. In order to use calculateEstimate, we need to know how many days have passed since the time the item was last purchased.

## Related Issue

Issue #11 

## Acceptance Criteria

- [ ]  When the user purchases an item, the item’s dateNextPurchased property is calculated using the calculateEstimate function and saved to the Firestore database
    - [ ]  dateNextPurchased is saved as a date, not a number

- [ ]  A getDaysBetweenDates function is exported from utils/dates.js and imported into api/firebase.js
    - [ ]  This function takes two JavaScript Dates and returns the number of days that have passed between them

## Type of Changes

Feature

## Updates

### Before

N/A

### After

N/A

## Testing Steps / QA Criteria

1. When a list item is clicked, a new value in dateNextPurchased should be entered into the database. This could be checked by looking at the individual item that was clicked, and seeing if the value has changed upon that click. 
    -  Until this is fully implemented, the dateNextPurchase that the item should be updating to is currently being console logged

2. The other half of this issue was an implementation of the getDaysBetweenDates function that will reside within the dates.js/utils file. When given two firebase-date formatted items, it will return the number of days that have passed.
