### PR TITLE
Improve home view

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -59,6 +59,7 @@ export function App() {
 								<Home
 									data={lists}
 									setListPath={setListPath}
+									listPath={listPath}
 									listName={listName}
 									exact
 								/>
@@ -66,7 +67,9 @@ export function App() {
 						/>
 						<Route
 							path="/list"
-							element={<List data={data} listPath={listPath} />}
+							element={
+								<List data={data} listPath={listPath} listName={listName} />
+							}
 						/>
 						<Route
 							path="/manage-list"

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -26,6 +26,8 @@ export function App() {
 		null,
 	);
 
+	const listName = listPath?.split('/')[1];
+
 	/**
 	 * This custom hook holds info about the current signed in user.
 	 * Check ./api/useAuth.jsx for its implementation.
@@ -53,7 +55,14 @@ export function App() {
 					<Route path="/" element={<Layout />}>
 						<Route
 							index
-							element={<Home data={lists} setListPath={setListPath} exact />}
+							element={
+								<Home
+									data={lists}
+									setListPath={setListPath}
+									listName={listName}
+									exact
+								/>
+							}
 						/>
 						<Route
 							path="/list"

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -23,6 +23,7 @@ export function useShoppingLists(userId, userEmail) {
 	// Start with an empty array for our data.
 	const initialState = [];
 	const [data, setData] = useState(initialState);
+	const [isLoading, setIsLoading] = useState(true);
 
 	useEffect(() => {
 		// If we don't have a userId or userEmail (the user isn't signed in),

--- a/src/components/AddListForm.jsx
+++ b/src/components/AddListForm.jsx
@@ -22,6 +22,8 @@ export default function AddListForm({ setListPath }) {
 				auth.currentUser.email,
 				newListName,
 			);
+			const newList = `${auth.currentUser.uid}/${newListName}`;
+			setListPath(newList);
 			setMessage('List created, redirecting in 1 second...');
 			setTimeout(() => {
 				navigate('/list');

--- a/src/components/AddListForm.jsx
+++ b/src/components/AddListForm.jsx
@@ -16,6 +16,11 @@ export default function AddListForm({ setListPath }) {
 	const handleSubmit = async (e) => {
 		e.preventDefault();
 
+		if (newListName === '') {
+			setMessage('Please add a name for your list');
+			return;
+		}
+
 		try {
 			await createList(
 				auth.currentUser.uid,

--- a/src/components/AddListForm.jsx
+++ b/src/components/AddListForm.jsx
@@ -1,0 +1,49 @@
+import { useState } from 'react';
+import { createList } from '../api/index.js';
+import { auth } from '../api/config.js';
+import { useNavigate } from 'react-router-dom';
+
+export default function AddListForm({ setListPath }) {
+	const [newListName, setNewListName] = useState('');
+	const [message, setMessage] = useState('');
+	const navigate = useNavigate();
+
+	const handleChange = (e) => {
+		const input = e.target.value;
+		setNewListName(input);
+	};
+
+	const handleSubmit = async (e) => {
+		e.preventDefault();
+
+		try {
+			await createList(
+				auth.currentUser.uid,
+				auth.currentUser.email,
+				newListName,
+			);
+			setMessage('List created, redirecting in 1 second...');
+			setTimeout(() => {
+				navigate('/list');
+			}, '1000');
+		} catch (error) {
+			console.error(error);
+			setMessage('List not created');
+		}
+	};
+
+	return (
+		<div>
+			<h3>Create a List</h3>
+			<form onSubmit={handleSubmit}>
+				<label htmlFor="newListName" name="newListName">
+					List Name
+				</label>
+				<input id="newListName" name="newListName" onChange={handleChange} />
+				<button type="submit">Create List</button>
+			</form>
+
+			<p>{message}</p>
+		</div>
+	);
+}

--- a/src/components/SelectListForm.jsx
+++ b/src/components/SelectListForm.jsx
@@ -1,0 +1,32 @@
+import { useNavigate } from 'react-router-dom';
+import { useState } from 'react';
+export default function SelectListForm({ data, listPath, setListPath }) {
+	const [selectedList, setSelectedList] = useState(listPath);
+	const navigate = useNavigate();
+	const handleSelectChange = (e) => {
+		const input = e.target.value;
+		setListPath(input);
+		setSelectedList(input?.split('/')[1]);
+	};
+	return (
+		<div>
+			<h3>
+				<label htmlFor="listSelector">Select a List</label>
+			</h3>
+			<select
+				id="listSelector"
+				value={selectedList}
+				onChange={handleSelectChange}
+			>
+				{data.map((data) => {
+					return (
+						<option key={data.path} value={data.path}>
+							{data.name}
+						</option>
+					);
+				})}
+			</select>
+			<button onClick={() => navigate('/list')}>View List</button>
+		</div>
+	);
+}

--- a/src/components/SingleList.jsx
+++ b/src/components/SingleList.jsx
@@ -5,9 +5,5 @@ export function SingleList({ name, path, setListPath }) {
 		setListPath(path);
 	}
 
-	return (
-		<li className="SingleList">
-			<button onClick={handleClick}>{path}</button>
-		</li>
-	);
+	return <option onClick={handleClick}>{name}</option>;
 }

--- a/src/components/SingleList.jsx
+++ b/src/components/SingleList.jsx
@@ -1,9 +1,9 @@
 import './SingleList.css';
 
 export function SingleList({ name, path, setListPath }) {
-	function handleClick() {
+	function handleChange() {
 		setListPath(path);
 	}
 
-	return <option onClick={handleClick}>{name}</option>;
+	return <option onChange={handleChange}>{name}</option>;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -57,8 +57,19 @@ html {
 body {
 	background-color: var(--color-bg);
 	color: var(--color-text);
-	font-family: -apple-system, BlinkMacSystemFont, avenir next, avenir, segoe ui,
-		helvetica neue, helvetica, Ubuntu, roboto, noto, arial, sans-serif;
+	font-family:
+		-apple-system,
+		BlinkMacSystemFont,
+		avenir next,
+		avenir,
+		segoe ui,
+		helvetica neue,
+		helvetica,
+		Ubuntu,
+		roboto,
+		noto,
+		arial,
+		sans-serif;
 	font-size: 1.8rem;
 	line-height: 1.4;
 	margin: 0;
@@ -75,7 +86,12 @@ code {
 	border-radius: 4px;
 	color: var(--color-text);
 	display: inline-block;
-	font-family: Menlo, Consolas, Monaco, Liberation Mono, Lucida Console,
+	font-family:
+		Menlo,
+		Consolas,
+		Monaco,
+		Liberation Mono,
+		Lucida Console,
 		monospace;
 	font-size: 0.9em;
 	padding: 0.15em 0.15em;
@@ -89,4 +105,13 @@ code {
 
 :root.theme-light code {
 	--color-bg: var(--color-gray-light);
+}
+
+form {
+	display: flex;
+	flex-direction: column;
+	width: 300px;
+}
+button {
+	width: 100px;
 }

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -5,20 +5,25 @@ import { createList } from '../api/index.js';
 import { auth } from '../api/config.js';
 import { useNavigate } from 'react-router-dom';
 
-export function Home({ data, setListPath }) {
+export function Home({ data, setListPath, listName }) {
 	const navigate = useNavigate();
-	const [listName, setListName] = useState('');
+	const [newListName, setnewListName] = useState('');
 	const [message, setMessage] = useState('');
+	const [selectedList, setSelectedList] = useState(listName);
 
 	const handleChange = (e) => {
-		setListName(e.target.value);
+		setnewListName(e.target.value);
 	};
 
 	const handleSubmit = async (e) => {
 		e.preventDefault();
 
 		try {
-			await createList(auth.currentUser.uid, auth.currentUser.email, listName);
+			await createList(
+				auth.currentUser.uid,
+				auth.currentUser.email,
+				newListName,
+			);
 			setMessage('List created, redirecting in 1 second...');
 			setTimeout(() => {
 				navigate('/list');
@@ -29,33 +34,51 @@ export function Home({ data, setListPath }) {
 		}
 	};
 
+	const handleSelectChange = (e) => {
+		setSelectedList(e.target.value);
+	};
+
 	return (
 		<div className="Home">
-			<p>
-				Hello from the home (<code>/</code>) page!
-			</p>
-			<form onSubmit={handleSubmit}>
-				<label htmlFor="listName" name="listName">
-					List Name
-				</label>
-				<input id="listName" name="listName" onChange={handleChange} />
-				<button type="submit">Submit</button>
-			</form>
+			<h4>Current List:</h4>
+			<h2>{listName}</h2>
+			<hr></hr>
+			<div>
+				<h3>Create a List</h3>
+				<form onSubmit={handleSubmit}>
+					<label htmlFor="newListName" name="newListName">
+						List Name
+					</label>
+					<input id="newListName" name="newListName" onChange={handleChange} />
+					<button type="submit">Create List</button>
+				</form>
 
-			<p>{message}</p>
+				<p>{message}</p>
+			</div>
+			<hr></hr>
 
-			<ul>
-				{data.map((data) => {
-					return (
-						<SingleList
-							key={data.name}
-							name={data.name}
-							path={data.path}
-							setListPath={setListPath}
-						/>
-					);
-				})}
-			</ul>
+			<div>
+				<h3>
+					<label htmlFor="listSelector">Select a List</label>
+				</h3>
+				<select
+					id="listSelector"
+					value={selectedList}
+					onChange={handleSelectChange}
+				>
+					{data.map((data) => {
+						return (
+							<SingleList
+								key={data.name}
+								name={data.name}
+								path={data.path}
+								setListPath={setListPath}
+							/>
+						);
+					})}
+				</select>
+				<button onClick={() => navigate('/list')}>View List</button>
+			</div>
 		</div>
 	);
 }

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -1,41 +1,15 @@
 import './Home.css';
 import { useState } from 'react';
-import { SingleList } from '../components/SingleList.jsx';
-import { createList } from '../api/index.js';
-import { auth } from '../api/config.js';
+import AddListForm from '../components/AddListForm.jsx';
 import { useNavigate } from 'react-router-dom';
-
-export function Home({ data, setListPath, listName }) {
+export function Home({ data, setListPath, listPath, listName }) {
+	console.log(data, listName);
+	const [selectedList, setSelectedList] = useState(listPath);
 	const navigate = useNavigate();
-	const [newListName, setnewListName] = useState('');
-	const [message, setMessage] = useState('');
-	const [selectedList, setSelectedList] = useState(listName);
-
-	const handleChange = (e) => {
-		setnewListName(e.target.value);
-	};
-
-	const handleSubmit = async (e) => {
-		e.preventDefault();
-
-		try {
-			await createList(
-				auth.currentUser.uid,
-				auth.currentUser.email,
-				newListName,
-			);
-			setMessage('List created, redirecting in 1 second...');
-			setTimeout(() => {
-				navigate('/list');
-			}, '1000');
-		} catch (error) {
-			console.error(error);
-			setMessage('List not created');
-		}
-	};
-
 	const handleSelectChange = (e) => {
-		setSelectedList(e.target.value);
+		const input = e.target.value;
+		setListPath(input);
+		setSelectedList(input?.split('/')[1]);
 	};
 
 	return (
@@ -43,18 +17,7 @@ export function Home({ data, setListPath, listName }) {
 			<h4>Current List:</h4>
 			<h2>{listName}</h2>
 			<hr></hr>
-			<div>
-				<h3>Create a List</h3>
-				<form onSubmit={handleSubmit}>
-					<label htmlFor="newListName" name="newListName">
-						List Name
-					</label>
-					<input id="newListName" name="newListName" onChange={handleChange} />
-					<button type="submit">Create List</button>
-				</form>
-
-				<p>{message}</p>
-			</div>
+			<AddListForm setListPath={setListPath} />
 			<hr></hr>
 
 			<div>
@@ -68,12 +31,15 @@ export function Home({ data, setListPath, listName }) {
 				>
 					{data.map((data) => {
 						return (
-							<SingleList
-								key={data.name}
-								name={data.name}
-								path={data.path}
-								setListPath={setListPath}
-							/>
+							<option key={data.path} value={data.path}>
+								{data.name}
+							</option>
+							// <SingleList
+							// 	key={data.name}
+							// 	name={data.name}
+							// 	path={data.path}
+							// 	setListPath={setListPath}
+							// />
 						);
 					})}
 				</select>

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -1,50 +1,22 @@
 import './Home.css';
-import { useState } from 'react';
 import AddListForm from '../components/AddListForm.jsx';
-import { useNavigate } from 'react-router-dom';
+import SelectListForm from '../components/SelectListForm.jsx';
 export function Home({ data, setListPath, listPath, listName }) {
-	console.log(data, listName);
-	const [selectedList, setSelectedList] = useState(listPath);
-	const navigate = useNavigate();
-	const handleSelectChange = (e) => {
-		const input = e.target.value;
-		setListPath(input);
-		setSelectedList(input?.split('/')[1]);
-	};
-
+	console.log(data);
 	return (
 		<div className="Home">
 			<h4>Current List:</h4>
 			<h2>{listName}</h2>
 			<hr></hr>
 			<AddListForm setListPath={setListPath} />
-			<hr></hr>
-
 			<div>
-				<h3>
-					<label htmlFor="listSelector">Select a List</label>
-				</h3>
-				<select
-					id="listSelector"
-					value={selectedList}
-					onChange={handleSelectChange}
-				>
-					{data.map((data) => {
-						return (
-							<option key={data.path} value={data.path}>
-								{data.name}
-							</option>
-							// <SingleList
-							// 	key={data.name}
-							// 	name={data.name}
-							// 	path={data.path}
-							// 	setListPath={setListPath}
-							// />
-						);
-					})}
-				</select>
-				<button onClick={() => navigate('/list')}>View List</button>
+				<p>----- OR -----</p>
 			</div>
+			<SelectListForm
+				data={data}
+				listPath={listPath}
+				setListPath={setListPath}
+			/>
 		</div>
 	);
 }

--- a/src/views/Layout.jsx
+++ b/src/views/Layout.jsx
@@ -21,7 +21,7 @@ export function Layout() {
 					<h1>Smart shopping list</h1>
 					{!!user ? (
 						<div>
-							<span>Signed in as {auth.currentUser.displayName}</span> (
+							<span>Welcome, {auth.currentUser.displayName}</span> (
 							<SignOutButton />)
 						</div>
 					) : (

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -3,8 +3,8 @@ import { ListItem } from '../components';
 import { useNavigate } from 'react-router-dom';
 import { comparePurchaseUrgency } from '../api/firebase';
 
-export function List({ data, listPath }) {
-	console.log(data.data, listPath);
+export function List({ data, listPath, listName }) {
+	console.log(data.data, listPath, listName);
 	const [input, setInput] = useState('');
 
 	const navigate = useNavigate();

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -4,7 +4,6 @@ import { useNavigate } from 'react-router-dom';
 import { comparePurchaseUrgency } from '../api/firebase';
 
 export function List({ data, listPath, listName }) {
-	console.log(data.data, listPath, listName);
 	const [input, setInput] = useState('');
 
 	const navigate = useNavigate();

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -3,7 +3,7 @@ import { ListItem } from '../components';
 import { useNavigate } from 'react-router-dom';
 import { comparePurchaseUrgency } from '../api/firebase';
 
-export function List({ data, listPath, listName }) {
+export function List({ data, listPath }) {
 	const [input, setInput] = useState('');
 
 	const navigate = useNavigate();


### PR DESCRIPTION
_For an example of how to fill this template out, [see this Pull Request](https://github.com/the-collab-lab/tcl-3-smart-shopping-list/pull/44)._

## Description

- [x]  - Make it clear that use can select existing list OR create new list
- [x]  - Remove User ID from list names
- [x]  - Dropdown for finding a list to select
- [x]  - List name displays somewhere on screen after selected
- [x]  - Remove: Hello from the home (/) page!
- [x]  - Remove: Signed in as user_name (Sign Out)
- [x]  - Update to Welcome, user_name
- [x]  - Add header to form, or some kind of description to make it more clear that this is to create a new list.
- [x]  - Update button copy to be more descriptive
- [x]  - Fix for this bug: https://github.com/orgs/the-collab-lab/projects/200/views/1?pane=issue&itemId=56874949


## Related Issue

#51 
#50 

## Acceptance Criteria

<!-- Include AC from the Github issue -->

## Type of Changes

Feature update and bug fix

## Updates

### Before

<!-- If UI feature, take provide screenshots -->

<img width="1007" alt="Screenshot 2024-03-21 at 6 52 55 PM" src="https://github.com/the-collab-lab/tcl-67-smart-shopping-list/assets/46732901/deeda9d9-70b2-4750-aaa8-42881e8ce84e"> 


### After

<!-- If UI feature, take provide screenshots -->
<img width="923" alt="Screenshot 2024-03-21 at 6 52 18 PM" src="https://github.com/the-collab-lab/tcl-67-smart-shopping-list/assets/46732901/60367acd-4d71-4c52-bf1e-1133c959be54">


## Testing Steps / QA Criteria

Creating a new list 

1. Create a new list, select create list. 
2. Should redirect to list page in 1 second

Selecting a list 

1. Select an existing list from the dropdown
2. Select list name in h2 should change to the selected list 
3. Clicking 'view list' should bring you to list page 
4. After going back home, list should still be selected 
