### PR TITLE
Updating home page/logged out page with new layouts

### DIFF
--- a/src/components/AddItemForm.jsx
+++ b/src/components/AddItemForm.jsx
@@ -57,52 +57,56 @@ export default function AddItemForm({ listPath, data }) {
 	};
 
 	return (
-		<form className="addItemForm" onSubmit={handleSubmit}>
-			<div className="addItemHeader">
-				<button>----</button>
-				<h2 data-testid="addItemForm-header">Add Item</h2>
-			</div>
-			<div>
-				<label htmlFor="itemName">Item Name: </label>
-				<div>
-					<input
-						data-testid="itemName"
-						onChange={(e) => setUserItem(e.target.value)}
-						type="text"
-						id="itemName"
-						value={userItem}
-					/>
+		<section>
+			<form className="addItemForm" onSubmit={handleSubmit}>
+				<div className="addItemHeader">
+					<button>----</button>
+					<h2 data-testid="addItemForm-header">Add Item</h2>
 				</div>
-			</div>
-			<span>When would you like a reminder to buy this item?</span>
-			<div className="addItemButtonGroup">
-				<button
-					value={7}
-					onClick={(e) => handleSelection(e)}
-					data-testid="replaceTime"
-				>
-					7 Days
-				</button>
-				<button value={14} onClick={(e) => handleSelection(e)}>
-					14 Days
-				</button>
-				<button value={30} onClick={(e) => handleSelection(e)}>
-					30 Days
-				</button>
-			</div>
-			<div>
-				<button className="submitButton" data-testid="submit-button">
-					Add Item
-				</button>
-			</div>
-			<div>
-				<span data-testid="addItemFormMessage">{message}</span>
-				{isSuccess && <span data-testid="addItemFormSuccess">Success!!</span>}
-				{error && (
-					<span data-testid="addItemFormError">Unable to add item to list</span>
-				)}
-				{isLoading && <span data-testid="addItemFormLoading">Adding...</span>}
-			</div>
-		</form>
+				<div>
+					<label htmlFor="itemName">Item Name: </label>
+					<div>
+						<input
+							data-testid="itemName"
+							onChange={(e) => setUserItem(e.target.value)}
+							type="text"
+							id="itemName"
+							value={userItem}
+						/>
+					</div>
+				</div>
+				<span>When would you like a reminder to buy this item?</span>
+				<div className="addItemButtonGroup">
+					<button
+						value={7}
+						onClick={(e) => handleSelection(e)}
+						data-testid="replaceTime"
+					>
+						7 Days
+					</button>
+					<button value={14} onClick={(e) => handleSelection(e)}>
+						14 Days
+					</button>
+					<button value={30} onClick={(e) => handleSelection(e)}>
+						30 Days
+					</button>
+				</div>
+				<div>
+					<button className="submitButton" data-testid="submit-button">
+						Add Item
+					</button>
+				</div>
+				<div>
+					<span data-testid="addItemFormMessage">{message}</span>
+					{isSuccess && <span data-testid="addItemFormSuccess">Success!!</span>}
+					{error && (
+						<span data-testid="addItemFormError">
+							Unable to add item to list
+						</span>
+					)}
+					{isLoading && <span data-testid="addItemFormLoading">Adding...</span>}
+				</div>
+			</form>
+		</section>
 	);
 }

--- a/src/components/AddListForm.jsx
+++ b/src/components/AddListForm.jsx
@@ -40,17 +40,20 @@ export default function AddListForm({ setListPath }) {
 	};
 
 	return (
-		<div>
-			<h3>Create a List</h3>
-			<form onSubmit={handleSubmit}>
-				<label htmlFor="newListName" name="newListName">
-					List Name
-				</label>
-				<input id="newListName" name="newListName" onChange={handleChange} />
-				<button type="submit">Create List</button>
-			</form>
-
-			<p>{message}</p>
+		<div className="sideBySide-section">
+			<div>
+				<h3>Create a List</h3>
+			</div>
+			<div>
+				<form onSubmit={handleSubmit}>
+					<label htmlFor="newListName" name="newListName">
+						List Name
+					</label>
+					<input id="newListName" name="newListName" onChange={handleChange} />
+					<button type="submit">Create List</button>
+					<p>{message}</p>
+				</form>
+			</div>
 		</div>
 	);
 }

--- a/src/components/ListSearchItems.jsx
+++ b/src/components/ListSearchItems.jsx
@@ -25,36 +25,38 @@ export default function ListSearchItems({ data, listPath }) {
 	}
 
 	return (
-		<div className="listSearchItems">
-			{data.length === 0 && (
-				<h2 data-testid="noItemsErrorMsg">You have no items in this list!</h2>
-			)}
-			{data.length !== 0 && (
-				<div className="searchInput">
-					<label className="searchLabel" htmlFor="searchItems">
-						Search your shopping list:{' '}
-					</label>
-					<form action="" onSubmit={(e) => e.preventDefault()}>
-						<input
-							onChange={handleInputChange}
-							id="searchItems"
-							value={input}
-							type="text"
-						/>
-					</form>
-					<button onClick={clearSearch}>Clear</button>
-				</div>
-			)}
-			<div>
-				{filteredItems.map((item) => (
-					<ListItem key={item.id} item={item} listPath={listPath} />
-				))}
-			</div>
-			{data.length > 0 && filteredItems.length === 0 && (
+		<section>
+			<div className="listSearchItems">
+				{data.length === 0 && (
+					<h2 data-testid="noItemsErrorMsg">You have no items in this list!</h2>
+				)}
+				{data.length !== 0 && (
+					<div className="searchInput">
+						<label className="searchLabel" htmlFor="searchItems">
+							Search your shopping list:{' '}
+						</label>
+						<form action="" onSubmit={(e) => e.preventDefault()}>
+							<input
+								onChange={handleInputChange}
+								id="searchItems"
+								value={input}
+								type="text"
+							/>
+						</form>
+						<button onClick={clearSearch}>Clear</button>
+					</div>
+				)}
 				<div>
-					<p>No match found for that filter query.</p>
+					{filteredItems.map((item) => (
+						<ListItem key={item.id} item={item} listPath={listPath} />
+					))}
 				</div>
-			)}
-		</div>
+				{data.length > 0 && filteredItems.length === 0 && (
+					<div>
+						<p>No match found for that filter query.</p>
+					</div>
+				)}
+			</div>
+		</section>
 	);
 }

--- a/src/components/LoggedOut.jsx
+++ b/src/components/LoggedOut.jsx
@@ -1,0 +1,11 @@
+export default function LoggedOut() {
+	return (
+		<section className="sideBySide-loggedOut">
+			<div>
+				<p>Log in to view your lists.</p>
+				<p>Plan your next grocery run with smart shopping list.</p>
+			</div>
+			<div>IMAGE PLACEHOLDER</div>
+		</section>
+	);
+}

--- a/src/components/SelectListForm.jsx
+++ b/src/components/SelectListForm.jsx
@@ -1,7 +1,12 @@
 import { useNavigate } from 'react-router-dom';
 import { useState } from 'react';
 
-export default function SelectListForm({ data, listPath, setListPath }) {
+export default function SelectListForm({
+	data,
+	listPath,
+	areListsLoading,
+	setListPath,
+}) {
 	const [selectedList, setSelectedList] = useState('');
 	const navigate = useNavigate();
 	const handleSelectChange = (e) => {
@@ -10,24 +15,32 @@ export default function SelectListForm({ data, listPath, setListPath }) {
 		setSelectedList(input?.split('/')[1]);
 	};
 	return (
-		<div>
-			<h3>
-				<label htmlFor="listSelector">Select a List</label>
-			</h3>
-			<select
-				id="listSelector"
-				value={selectedList}
-				onChange={handleSelectChange}
-			>
-				{data.map((data) => {
-					return (
-						<option key={data.path} value={data.path}>
-							{data.name}
-						</option>
-					);
-				})}
-			</select>
-			<button onClick={() => navigate('/list')}>View List</button>
-		</div>
+		<section className="sideBySide-section">
+			{areListsLoading ? (
+				<div>Loading lists...</div>
+			) : (
+				<div>
+					<select
+						id="listSelector"
+						value={selectedList}
+						onChange={handleSelectChange}
+					>
+						{data.map((data) => {
+							return (
+								<option key={data.path} value={data.path}>
+									{data.name}
+								</option>
+							);
+						})}
+					</select>
+					<button onClick={() => navigate('/list')}>View List</button>
+				</div>
+			)}
+			<div>
+				<h3>
+					<label htmlFor="listSelector">Select a List</label>
+				</h3>
+			</div>
+		</section>
 	);
 }

--- a/src/components/ShareForm.jsx
+++ b/src/components/ShareForm.jsx
@@ -35,8 +35,8 @@ const ShareForm = ({ listPath }) => {
 		);
 	};
 	return (
-		<>
-			<div className="div1">
+		<section className="sideBySide-section">
+			<div>
 				<form onSubmit={handleSubmit}>
 					<div>
 						<label htmlFor="email">Email: </label>
@@ -63,11 +63,11 @@ const ShareForm = ({ listPath }) => {
 				</form>
 			</div>
 
-			<div className="div2">
+			<div>
 				<h2 data-testid="shareForm-header">Share your list with a Collabie!</h2>
 				<span>Enter the email of another existing user.</span>
 			</div>
-		</>
+		</section>
 	);
 };
 

--- a/src/index.css
+++ b/src/index.css
@@ -38,6 +38,11 @@
 	box-sizing: border-box;
 }
 
+a {
+	text-decoration: none;
+	color: inherit;
+}
+
 /**
  * Make sure the app fills the height of the screen.
  */
@@ -114,4 +119,43 @@ form {
 }
 button {
 	width: 100px;
+}
+
+@media screen and (min-width: 780px) {
+	/* List Share */
+
+	.sideBySide-section {
+		display: flex;
+		flex-direction: row;
+		height: 50vh;
+		width: 100%;
+	}
+	.sideBySide-section > div {
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+		align-items: center;
+		height: 100%;
+		width: 100%;
+		padding: 50px;
+		border: 1px solid black;
+	}
+}
+
+.sideBySide-loggedOut {
+	display: flex;
+	flex-direction: row;
+	height: 90vh;
+	width: 100%;
+}
+
+.sideBySide-loggedOut > div {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	align-items: center;
+	height: 100%;
+	width: 100%;
+	padding: 50px;
+	border: 1px solid black;
 }

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -14,24 +14,17 @@ export function Home({
 			{!listPath ? (
 				<h4>No list currently selected!</h4>
 			) : (
-				<h4>Current List:</h4>
+				<h4>Current List:{listName}</h4>
 			)}
 
-			<h2>{listName}</h2>
-			<hr></hr>
 			<AddListForm setListPath={setListPath} />
-			<div>
-				<p>----- OR -----</p>
-			</div>
-			{areListsLoading ? (
-				<div>Loading lists...</div>
-			) : (
-				<SelectListForm
-					data={data}
-					listPath={listPath}
-					setListPath={setListPath}
-				/>
-			)}
+
+			<SelectListForm
+				data={data}
+				listPath={listPath}
+				areListsLoading={areListsLoading}
+				setListPath={setListPath}
+			/>
 		</div>
 	);
 }

--- a/src/views/Layout.css
+++ b/src/views/Layout.css
@@ -18,12 +18,15 @@
 	padding-inline: min(5dvw, 3.2rem);
 } */
 
-/* .Layout-header {
+.Layout-header {
 	background-color: var(--color-bg);
 	padding-bottom: 0.5rem;
 	padding-top: max(env(safe-area-inset-top), 1rem);
 	text-align: center;
-} */
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+}
 
 /* .Layout-header > h1 {
 	margin: 0;

--- a/src/views/Layout.jsx
+++ b/src/views/Layout.jsx
@@ -3,6 +3,7 @@ import { Outlet, NavLink } from 'react-router-dom';
 import './Layout.css';
 import { auth } from '../api/config.js';
 import { useAuth, SignInButton, SignOutButton } from '../api/useAuth.jsx';
+import LoggedOut from '../components/LoggedOut.jsx';
 
 /**
  * TODO: The links defined in this file don't work!
@@ -19,7 +20,10 @@ export function Layout() {
 			{!!user ? (
 				<>
 					<header className="Layout-header">
-						<h1>Smart shopping list</h1>
+						<a href="/">
+							<h1>Smart shopping list</h1>
+						</a>
+
 						<div>
 							<span>Welcome, {auth.currentUser.displayName}</span> (
 							<SignOutButton />)
@@ -28,7 +32,7 @@ export function Layout() {
 					<main className="Layout-main">
 						<Outlet />
 					</main>
-					<nav className="Nav">
+					{/* <nav className="Nav">
 						<div className="Nav-container">
 							<NavLink to="/" className="Nav-link">
 								Home
@@ -37,7 +41,7 @@ export function Layout() {
 								List
 							</NavLink>
 						</div>
-					</nav>
+					</nav> */}
 				</>
 			) : (
 				<>
@@ -47,7 +51,7 @@ export function Layout() {
 							<SignInButton />
 						</div>
 					</header>
-					<div>Please sign in to view lists.</div>
+					<LoggedOut />
 				</>
 			)}
 		</div>

--- a/src/views/Layout.jsx
+++ b/src/views/Layout.jsx
@@ -1,4 +1,4 @@
-import { Outlet, NavLink } from 'react-router-dom';
+import { Outlet } from 'react-router-dom';
 
 import './Layout.css';
 import { auth } from '../api/config.js';
@@ -32,16 +32,6 @@ export function Layout() {
 					<main className="Layout-main">
 						<Outlet />
 					</main>
-					{/* <nav className="Nav">
-						<div className="Nav-container">
-							<NavLink to="/" className="Nav-link">
-								Home
-							</NavLink>
-							<NavLink to="/list" className="Nav-link">
-								List
-							</NavLink>
-						</div>
-					</nav> */}
 				</>
 			) : (
 				<>

--- a/src/views/List.css
+++ b/src/views/List.css
@@ -243,7 +243,7 @@ input {
 
 	/* List Share */
 
-	.share {
+	/* .share {
 		display: flex;
 		flex-direction: row;
 		height: 30vh;
@@ -260,5 +260,5 @@ input {
 		width: 100%;
 		padding: 50px;
 		border: 1px solid black;
-	}
+	} */
 }

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -23,18 +23,9 @@ export function List({ data, isShoppingListLoading, listPath, listName }) {
 			<section>
 				<h2>{listName}</h2>
 			</section>
-			<section>
-				<AddItemForm listPath={listPath} data={data} />
-			</section>
-			<section>
-				<ListSearchItems listPath={listPath} data={data} />
-			</section>
-			<section className="share">
-				<ShareForm listPath={listPath} />
-			</section>
-			<section className="logOutFooter">
-				<SignOutButton />
-			</section>
+			<AddItemForm listPath={listPath} data={data} />
+			<ListSearchItems listPath={listPath} data={data} />
+			<ShareForm listPath={listPath} />
 		</main>
 	);
 }


### PR DESCRIPTION
_For an example of how to fill this template out, [see this Pull Request](https://github.com/the-collab-lab/tcl-3-smart-shopping-list/pull/44)._

## Description

- Updating home page and logged out page according to low fidelity mockups. 
- Removed nav links
- H1 is now link back to home page 


## Related Issue

<!-- If you write "closes" followed by the Github issue number, it will automatically close the issue for you when the PR merges -->
#87 

## Acceptance Criteria

<!-- Include AC from the Github issue -->

## Type of Changes

Design update.

## Updates

### Before

Logged out page
<img width="1440" alt="Screenshot 2024-03-28 at 7 00 02 PM" src="https://github.com/the-collab-lab/tcl-67-smart-shopping-list/assets/46732901/7be81c6b-693c-4967-96f8-1eb7968e11d3">
Logged in home page.
<img width="1440" alt="Screenshot 2024-03-28 at 7 00 11 PM" src="https://github.com/the-collab-lab/tcl-67-smart-shopping-list/assets/46732901/485095c0-f9c6-4c98-83c8-a4988aa139a4">

### After
**Home page**
<!-- If UI feature, take provide screenshots -->
<img width="1440" alt="Screenshot 2024-03-28 at 6 56 40 PM" src="https://github.com/the-collab-lab/tcl-67-smart-shopping-list/assets/46732901/11d156a9-fabf-4ee5-96b3-4269050c6ac0">
<img width="1439" alt="Screenshot 2024-03-28 at 6 53 44 PM" src="https://github.com/the-collab-lab/tcl-67-smart-shopping-list/assets/46732901/bf45a333-4538-449d-9443-7a383995b24f">

**Logged out page**
<img width="1440" alt="Screenshot 2024-03-28 at 6 54 30 PM" src="https://github.com/the-collab-lab/tcl-67-smart-shopping-list/assets/46732901/bf3423d2-cc99-4e14-846e-b78968a2efcb">

## Testing Steps / QA Criteria

- View home page after logging in
- Log out and view logged out page
