### PR TITLE
Add item section toggle 89

### DIFF
--- a/src/components/AddItemForm.jsx
+++ b/src/components/AddItemForm.jsx
@@ -57,28 +57,29 @@ export default function AddItemForm({ listPath, data }) {
 		setItemDuration(Number(e.target.value));
 	};
 
-	function handleAddItemToggle() {
+	function handleAddItemToggle(e) {
+		e.preventDefault();
 		addItemToggle === '+' ? setAddItemToggle('-') : setAddItemToggle('+');
 	}
 
 	return (
-		<section
-			className={
-				addItemToggle === '+' ? 'addItemMinimized' : 'addItemMaximized'
-			}
-		>
-			<form className="addItemForm" onSubmit={handleSubmit}>
-				<div className="addItemHeader">
-					<button
-						className={(addItemToggle, 'addItemButton')}
-						onClick={() => {
-							handleAddItemToggle();
-						}}
-					>
-						{addItemToggle}
-					</button>
-					<h2 data-testid="addItemForm-header">Add Item</h2>
-				</div>
+		<section className="addItemSection">
+			<header className="addItemHeader">
+				<button
+					className={(addItemToggle, 'addItemButton')}
+					onClick={(e) => handleAddItemToggle(e)}
+				>
+					{addItemToggle}
+				</button>
+				<h2 data-testid="addItemForm-header">Add Item</h2>
+			</header>
+			<form
+				className={
+					(addItemToggle === '+' ? 'addItemMinimized' : 'addItemMaximized') +
+					' addItemForm'
+				}
+				onSubmit={handleSubmit}
+			>
 				<div>
 					<label htmlFor="itemName">Item Name: </label>
 					<div>

--- a/src/components/AddItemForm.jsx
+++ b/src/components/AddItemForm.jsx
@@ -57,13 +57,12 @@ export default function AddItemForm({ listPath, data }) {
 		setItemDuration(Number(e.target.value));
 	};
 
-	function handleAddItemToggle(e) {
+	function handleAddItemToggle() {
 		addItemToggle === '+' ? setAddItemToggle('-') : setAddItemToggle('+');
 	}
 
 	return (
 		<section
-			id="addItemToggle"
 			className={
 				addItemToggle === '+' ? 'addItemMinimized' : 'addItemMaximized'
 			}
@@ -72,8 +71,8 @@ export default function AddItemForm({ listPath, data }) {
 				<div className="addItemHeader">
 					<button
 						className={(addItemToggle, 'addItemButton')}
-						onClick={(e) => {
-							handleAddItemToggle(e);
+						onClick={() => {
+							handleAddItemToggle();
 						}}
 					>
 						{addItemToggle}

--- a/src/components/AddItemForm.jsx
+++ b/src/components/AddItemForm.jsx
@@ -14,6 +14,7 @@ export default function AddItemForm({ listPath, data }) {
 	const [message, setMessage] = useState('');
 	const [userItem, setUserItem] = useState('');
 	const [itemDuration, setItemDuration] = useState(7);
+	const [addItemToggle, setAddItemToggle] = useState('+');
 
 	const normalizedItemNames = useMemo(() => {
 		return data?.map((item) => normalizeInput(item.name));
@@ -56,11 +57,27 @@ export default function AddItemForm({ listPath, data }) {
 		setItemDuration(Number(e.target.value));
 	};
 
+	function handleAddItemToggle(e) {
+		addItemToggle === '+' ? setAddItemToggle('-') : setAddItemToggle('+');
+	}
+
 	return (
-		<section>
+		<section
+			id="addItemToggle"
+			className={
+				addItemToggle === '+' ? 'addItemMinimized' : 'addItemMaximized'
+			}
+		>
 			<form className="addItemForm" onSubmit={handleSubmit}>
 				<div className="addItemHeader">
-					<button>----</button>
+					<button
+						className={(addItemToggle, 'addItemButton')}
+						onClick={(e) => {
+							handleAddItemToggle(e);
+						}}
+					>
+						{addItemToggle}
+					</button>
 					<h2 data-testid="addItemForm-header">Add Item</h2>
 				</div>
 				<div>

--- a/src/views/List.css
+++ b/src/views/List.css
@@ -29,6 +29,11 @@ input {
 }
 
 /* Add Item Form */
+
+.addItemSection {
+	padding: 0;
+}
+
 .addItemForm form {
 	display: flex;
 	gap: 1em;
@@ -54,7 +59,7 @@ input {
 }
 
 .addItemMinimized {
-	overflow: hidden;
+	display: none;
 	animation-name: slideUp;
 	animation-duration: 0.2;
 	animation-timing-function: linear;

--- a/src/views/List.css
+++ b/src/views/List.css
@@ -40,13 +40,13 @@ input {
 		height: 5em;
 	}
 	to {
-		height: auto;
+		height: 28em;
 	}
 }
 
 @keyframes slideUp {
 	from {
-		height: auto;
+		height: 28em;
 	}
 	to {
 		height: 5em;
@@ -54,17 +54,18 @@ input {
 }
 
 .addItemMinimized {
-	height: 5em;
 	overflow: hidden;
-	/* animation-name: slideDown;
-	animation-duration: 2s; */
+	animation-name: slideUp;
+	animation-duration: 0.2;
+	animation-timing-function: linear;
+	animation-fill-mode: forwards;
 }
 
 .addItemMaximized {
-	height: auto;
-	/* animation-name: slideDown;
-	animation-duration: 4s;
-	animation-timing-function: linear; */
+	overflow: hidden;
+	animation-name: slideDown;
+	animation-duration: 0.2s;
+	animation-timing-function: linear;
 }
 
 .addItemButton {
@@ -202,6 +203,41 @@ input {
 
 	.submitButton {
 		width: 14em;
+	}
+
+	@keyframes slideDown {
+		from {
+			height: 5em;
+		}
+
+		to {
+			height: 42em;
+		}
+	}
+
+	@keyframes slideUp {
+		from {
+			height: 42em;
+		}
+		to {
+			height: 5em;
+		}
+	}
+
+	.addItemMinimized {
+		overflow: hidden;
+		animation-name: slideUp;
+		animation-duration: 0.2;
+		animation-timing-function: linear;
+		animation-fill-mode: forwards;
+	}
+
+	.addItemMaximized {
+		overflow: hidden;
+		animation-name: slideDown;
+		animation-duration: 0.2s;
+		animation-timing-function: linear;
+		animation-fill-mode: forwards;
 	}
 
 	/* Search List */

--- a/src/views/List.css
+++ b/src/views/List.css
@@ -35,6 +35,42 @@ input {
 	text-align: center;
 }
 
+@keyframes slideDown {
+	from {
+		height: 5em;
+	}
+	to {
+		height: auto;
+	}
+}
+
+@keyframes slideUp {
+	from {
+		height: auto;
+	}
+	to {
+		height: 5em;
+	}
+}
+
+.addItemMinimized {
+	height: 5em;
+	overflow: hidden;
+	/* animation-name: slideDown;
+	animation-duration: 2s; */
+}
+
+.addItemMaximized {
+	height: auto;
+	/* animation-name: slideDown;
+	animation-duration: 4s;
+	animation-timing-function: linear; */
+}
+
+.addItemButton {
+	width: 2em;
+}
+
 .addItemHeader {
 	display: flex;
 	flex-direction: row;


### PR DESCRIPTION
## Description

Added a toggle feature to list view's add item section

Clicking the button will cause the section to toggle downwards into an expanded view, and clicking the button again will toggle it back upwards into a minimized view.

While the animation works smoothly going down, I seem to be having trouble getting it back upwards in the same manner...Happy to implement suggestions on fixing that bit! But I don't think it's app-breaking if the _animated_ up-toggle isn't done.

## Related Issue

closes #89 

## Acceptance Criteria

Button hides and expands Add Item form on list view.

## Type of Changes

Enhancement

## Updates
![addItem](https://github.com/the-collab-lab/tcl-67-smart-shopping-list/assets/14006060/bab00640-4b71-4db1-8427-f78a92bbedd1)

## Testing Steps / QA Criteria

With a list selected, navigate to the list view. Click the toggle button next to "Add Item"